### PR TITLE
JPG images not showing

### DIFF
--- a/xkcd.el
+++ b/xkcd.el
@@ -93,7 +93,7 @@ The return value is a string."
     ((string= substr "png")
      'png)
     ((string= substr "jpg")
-     'jpg)
+     'jpeg)
     (t 'gif))))
 
 (defun xkcd-download (url num)


### PR DESCRIPTION
Only the image title (e.g. `17: What If`) and the error message `Invalid image type `jpg'` are shown. When trying to view an jpg. 
