### PR TITLE
Add prefix arg to next/prev fn, add copy-link fn

### DIFF
--- a/xkcd.el
+++ b/xkcd.el
@@ -59,7 +59,9 @@
   "A xkcd reader for Emacs"
   :group 'multimedia)
 
-(defcustom xkcd-cache-dir "~/.emacs.d/xkcd/"
+(defcustom xkcd-cache-dir (let ((dir (concat user-emacs-directory "xkcd/")))
+                            (make-directory dir :parents)
+                            dir)
   "Directory to cache images and json files to."
   :group 'xkcd
   :type 'directory)
@@ -98,9 +100,6 @@ The return value is a string."
 
 (defun xkcd-download (url num)
   "Download the image linked by URL to NUM.  If NUM arleady exists, do nothing."
-  ;;check if the cache directory exists
-  (unless (file-exists-p xkcd-cache-dir)
-    (make-directory xkcd-cache-dir))
   (let ((name (format "%s%s.%s" xkcd-cache-dir (number-to-string num)
 		      (substring url (- (length url) 3)))))
     (if (file-exists-p name)
@@ -175,15 +174,21 @@ If the image is a gif, animate it."
       (setq xkcd-alt (cdr (assoc 'alt json-assoc)))
       (message title))))
 
-(defun xkcd-next ()
+(defun xkcd-next (arg)
   "Get next xkcd."
-  (interactive)
-  (xkcd-get (+ xkcd-cur 1)))
+  (interactive "p")
+  (let ((num (+ xkcd-cur arg)))
+    (when (> num xkcd-latest)
+      (setq num xkcd-latest))
+    (xkcd-get num)))
 
-(defun xkcd-prev ()
+(defun xkcd-prev (arg)
   "Get previous xkcd."
-  (interactive)
-  (xkcd-get (- xkcd-cur 1)))
+  (interactive "p")
+  (let ((num (- xkcd-cur arg)))
+    (when (< num 1)
+      (setq num 1))
+    (xkcd-get num)))
 
 (defun xkcd-rand ()
   "Show random xkcd."
@@ -242,6 +247,14 @@ If the image is a gif, animate it."
   (interactive)
   (browse-url-default-browser (concat "http://www.explainxkcd.com/wiki/index.php/"
                                       (number-to-string xkcd-cur))))
+
+(defun xkcd-copy-link ()
+  "Save the link to the current comic to the kill-ring."
+  (interactive)
+  (let ((link (concat "http://xkcd.com/"
+                      (number-to-string xkcd-cur))))
+    (kill-new link)
+    (message link)))
 
 (provide 'xkcd)
 ;;; xkcd.el ends here


### PR DESCRIPTION
- It is now possible to navigate the next/prev comics in "jumps"
  Example: C-u M-x xkcd-next will take you from comic 1000 to 1004
           C-u M-x xkcd-prev will take you from comic 1000 to 996
- Add xkcd-copy-link fn to copy the link to the current comic
- Move the xkcd-custom-dir creation to defcustom.. that way that
  directory existence check will happen just once each time xkcd is
  loaded.
- Replace hard-coded `~/.emacs.d` with user-emacs-directory