### PR TITLE
Bump version to 1.2 for NonGNU ELPA

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,13 @@
+* Whatever goes upon two legs is an enemy.
+
+* Whatever goes upon four legs, or has wings, is a friend.
+
+* No animal shall wear clothes.
+
+* No animal shall sleep in a bed.
+
+* No animal shall drink alcohol.
+
+* No animal shall kill any other animal without cause.
+
+* All animals are equal.

--- a/xkcd.el
+++ b/xkcd.el
@@ -4,7 +4,7 @@
 
 ;; Url: https://github.com/vibhavp/emacs-xkcd
 ;; Author: Vibhav Pant <vibhavp@gmail.com>
-;; Version: 1.0
+;; Version: 1.2
 ;; Package-Requires: ((json "1.3"))
 ;; Keywords: xkcd webcomic
 


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

However, NonGNU ELPA has a requirement that all files must have a clear statement of its license and copyright status. I believe this patch would be sufficient to fulfill this requirement.

The rules for accepting a package into NonGNU ELPA are here, for your reference:
https://git.savannah.gnu.org/cgit/emacs/nongnu.git/tree/README.org#n133

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the ";;; Version: NNN" commentary header in the main file of this repository. This is similar to MELPA Stable, but we do not care about the git tag; only the commentary header.  In the future, you can bump the package version (thereby releasing a new version) when you think it makes sense and at your convenience.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!